### PR TITLE
Enumerable methods rebuilt

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,42 @@
+AllCops:
+  Exclude:
+    - "README.md"
+    - "Guardfile"
+    - "Rakefile"
+
+  DisplayCopNames: true
+
+Layout/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 20
+Metrics/AbcSize:
+  Max: 50
+Metrics/ClassLength:
+  Max: 150
+Metrics/BlockLength:
+  ExcludedMethods: ['describe']
+  Max: 30
+
+
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/DefWithParentheses:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Layout/HashAlignment:
+  EnforcedColonStyle: key
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,17 @@
+# add the linters you want stickler to use for this project
+linters:
+  rubocop:
+    display_cop_names: true
+    # indicate where is the config file for stylelint
+    config: "./rubocop.yml"
+
+files:
+  ignore:
+    - "Guardfile"
+    - "Rakefile"
+    - "node_modules/**/*"
+    
+# PLEASE DO NOT enable auto fixing options
+# if you need extra support from you linter - do it in your local env as described in README for this config
+# find full documentation here: https://stickler-ci.com/docs
+

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The rewritten Enumerable methods are:
 - Clone this repository to your local machine or download the files.
 
 ### Usage
-- Navigate to the project folder and run the main.tb file, using: ruby main.rb
+- Navigate to the project folder and run the main.rb file, using: ruby main.rb
 - To run the methods created here, you must call them from main.rb or create a new file with its purpose.
 
 ## 👤 Author 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# enumerable-methods

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# My Enumerable Methods
+
+> This project presents a rebuilt list of methods from Ruby Enumerable module.
+
+The rewritten Enumerable methods are:
+- each -> my_each
+- each_with_index -> my_each_with_index
+- select -> my_select
+- all? -> my_all?
+- any? -> my_any?
+- none? -> my_none?
+- count -> my_count
+- map -> my_map (additional refactor to accept a proc as a parameter, or a block)
+- inject -> my_inject
+
+## Built With
+
+- Ruby
+- Rubocop (linter)
+
+## Getting started
+
+### Prerequisites
+- To run this project, you must have Ruby installed in your computer.
+
+### Setup
+- Clone this repository to your local machine or download the files.
+
+### Usage
+- Navigate to the project folder and run the main.tb file, using: ruby main.rb
+- To run the methods created here, you must call them from main.rb or create a new file with its purpose.
+
+## 👤 Author 
+
+- Github: [@flpfar](https://github.com/flpfar)
+- Twitter: [@flpfar](https://twitter.com/flpfar)
+- Linkedin: [Felipe Augusto Rosa](https://www.linkedin.com/in/felipe-augusto-rosa-7b96a4b1)
+
+## 🤝 Contributing
+
+Contributions, issues and feature requests are welcome!
+Feel free to check the [issues page](issues/).
+
+## Show your support
+
+Give a ⭐️ if you like this project!

--- a/main.rb
+++ b/main.rb
@@ -5,29 +5,20 @@ module Enumerable
   def my_each
     return to_enum unless block_given?
 
-    object = self
-    object.size.times do |n|
-      yield object[n]
-    end
+    size.times { |n| yield self[n] }
   end
 
   def my_each_with_index
     return to_enum unless block_given?
 
-    object = self
-    object.size.times do |n|
-      yield object[n], n
-    end
+    size.times { |n| yield self[n], n }
   end
 
   def my_select
     return to_enum unless block_given?
 
     array = []
-    object = self
-    object.my_each do |n|
-      array.push(n) if yield(n)
-    end
+    my_each { |n| array.push(n) if yield(n) }
     array
   end
 end

--- a/main.rb
+++ b/main.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
-# rubocop:disable Layout/LineLength
 
 # Adding my_methods to Enumerable module
 module Enumerable
@@ -104,10 +103,14 @@ module Enumerable
     end
 
     unless arg.nil?
-      memo = (my_inject { |oper, n| oper.public_send(arg, n) }).public_send(arg, initial)
+      memo = (my_inject { |oper, n| oper.public_send(arg, n) })
+      memo = memo.public_send(arg, initial)
     end
 
-    (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) } if block_given? && arg.nil?
+    if block_given? && arg.nil?
+      (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) }
+    end
+
     memo
   end
 
@@ -115,7 +118,5 @@ module Enumerable
     array.my_inject(:*)
   end
 end
-
-
 
 # rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -37,13 +37,13 @@ module Enumerable
     true
   end
 
-  def my_any?(arg = nil)
+  def my_any?(arg = nil, &block)
     if arg.is_a?(Regexp)
       my_each { |n| return true if arg.match(n) }
     elsif arg.is_a?(Integer) || arg.is_a?(String)
       my_each { |n| return true if n == arg }
     elsif block_given?
-      my_each { |n| return true if yield(n) }
+      my_each { |n| return true if block.call(n) }
     elsif arg.nil?
       my_each { |n| return true if n }
     else
@@ -52,19 +52,8 @@ module Enumerable
     false
   end
 
-  def my_none?(arg = nil)
-    if arg.is_a?(Regexp)
-      my_each { |n| return false if arg.match(n) }
-    elsif arg.is_a?(Integer) || arg.is_a?(String)
-      my_each { |n| return false if n == arg }
-    elsif block_given?
-      my_each { |n| return false if yield(n) }
-    elsif arg.nil?
-      my_each { |n| return false if n }
-    else
-      my_each { |n| return false if n.is_a?(arg) }
-    end
-    true
+  def my_none?(arg = nil, &block)
+    !my_any?(arg, &block)
   end
 
   def my_count(arg = nil)

--- a/main.rb
+++ b/main.rb
@@ -100,13 +100,16 @@ module Enumerable
       initial, memo = 1 if arg == :/ || arg == :* && initial.zero?
     end
 
-    unless arg.nil?
-      memo = (my_inject { |oper, n| oper.public_send(arg, n) })
-      memo = memo.public_send(arg, initial)
+    memo = (my_inject { |oper, n| oper.public_send(arg, n) }).public_send(arg, initial) unless arg.nil?
+
+    if block_given?
+      if initial.zero?
+        (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) }
+      else
+        obj.size.times { |n| initial = yield(initial, obj[n]) }
+        memo = initial
+      end
     end
-
-    (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) } if block_given? && arg.nil?
-
     memo
   end
 

--- a/main.rb
+++ b/main.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
+# rubocop:disable Layout/LineLength
 
 # Adding methods to Enumerable module
 module Enumerable
@@ -87,8 +88,26 @@ module Enumerable
     return to_enum unless block_given?
 
     obj = to_a
-    obj.size.times { |n| obj[n] = yield obj[n] }
+    obj.size.times { |n| obj[n] = yield(obj[n]) }
     obj
+  end
+
+  def my_inject(initial = 0, arg = nil)
+    obj = to_a
+    memo = obj[0]
+
+    if initial.is_a?(Symbol)
+      arg = initial
+      initial = 0
+      initial, memo = 1 if arg == :/ || arg == :* && initial.zero?
+    end
+
+    unless arg.nil?
+      memo = (my_inject { |oper, n| oper.public_send(arg, n) }).public_send(arg, initial)
+    end
+
+    (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) } if block_given? && arg.nil?
+    memo
   end
 end
 

--- a/main.rb
+++ b/main.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
 # rubocop:disable Layout/LineLength
 
-# Adding methods to Enumerable module
+# Adding my_methods to Enumerable module
 module Enumerable
   def my_each
     return to_enum unless block_given?
@@ -84,11 +84,12 @@ module Enumerable
     count
   end
 
-  def my_map
-    return to_enum unless block_given?
+  def my_map(proc = nil, &block)
+    return to_enum unless proc || block
 
+    proc = block if block
     obj = to_a
-    obj.size.times { |n| obj[n] = yield(obj[n]) }
+    obj.size.times { |n| obj[n] = proc.call(obj[n]) }
     obj
   end
 
@@ -109,6 +110,12 @@ module Enumerable
     (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) } if block_given? && arg.nil?
     memo
   end
+
+  def multiply_els(array)
+    array.my_inject(:*)
+  end
 end
+
+
 
 # rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -84,7 +84,7 @@ module Enumerable
   def my_map(proc = nil, &block)
     return to_enum unless proc || block
 
-    proc = block if block
+    proc = block if block && !proc
     obj = to_a
     obj.size.times { |n| obj[n] = proc.call(obj[n]) }
     obj
@@ -114,8 +114,10 @@ module Enumerable
   end
 end
 
-def multiply_els(array)
-  array.my_inject(:*)
+module TestEnumerable
+  def multiply_els(array)
+    array.my_inject(:*)
+  end
 end
 
 # rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
+
 # Adding methods to Enumerable module
 module Enumerable
   def my_each
@@ -21,4 +23,36 @@ module Enumerable
     my_each { |n| array.push(n) if yield(n) }
     array
   end
+
+  def my_all?(arg = nil)
+    if block_given? && arg.nil?
+      my_each { |n| return false unless yield(n) }
+    elsif arg.nil?
+      my_each { |n| return false unless n }
+    elsif arg.is_a?(Regexp)
+      my_each { |n| return false unless arg.match(n) }
+    elsif arg.is_a?(Integer) || arg.is_a?(String)
+      my_each { |n| return false unless n == arg }
+    else
+      my_each { |n| return false unless n.is_a?(arg) }
+    end
+    true
+  end
+
+  def my_any?(arg = nil)
+    if block_given? && arg.nil?
+      my_each { |n| return true if yield(n) }
+    elsif arg.nil?
+      my_each { |n| return true if n }
+    elsif arg.is_a?(Regexp)
+      my_each { |n| return true if arg.match(n) }
+    elsif arg.is_a?(Integer) || arg.is_a?(String)
+      my_each { |n| return true if n == arg }
+    else
+      my_each { |n| return true if n.is_a?(arg) }
+    end
+    false
+  end
 end
+
+# rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -1,6 +1,4 @@
-# frozen_string_literal: true
-
-# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
 # Adding my_methods to Enumerable module
 module Enumerable
@@ -107,9 +105,7 @@ module Enumerable
       memo = memo.public_send(arg, initial)
     end
 
-    if block_given? && arg.nil?
-      (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) }
-    end
+    (obj.size - 1).times { |n| memo = yield(memo, obj[n + 1]) } if block_given? && arg.nil?
 
     memo
   end

--- a/main.rb
+++ b/main.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Adding methods to Enumerable module
+module Enumerable
+  def my_each
+    return to_enum unless block_given?
+
+    object = self
+    object.size.times do |n|
+      yield object[n]
+    end
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -112,10 +112,10 @@ module Enumerable
     end
     memo
   end
+end
 
-  def multiply_els(array)
-    array.my_inject(:*)
-  end
+def multiply_els(array)
+  array.my_inject(:*)
 end
 
 # rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -19,4 +19,15 @@ module Enumerable
       yield object[n], n
     end
   end
+
+  def my_select
+    return to_enum unless block_given?
+
+    array = []
+    object = self
+    object.my_each do |n|
+      array.push(n) if yield(n)
+    end
+    array
+  end
 end

--- a/main.rb
+++ b/main.rb
@@ -82,6 +82,14 @@ module Enumerable
     end
     count
   end
+
+  def my_map
+    return to_enum unless block_given?
+
+    obj = to_a
+    obj.size.times { |n| obj[n] = yield obj[n] }
+    obj
+  end
 end
 
 # rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -53,6 +53,35 @@ module Enumerable
     end
     false
   end
+
+  def my_none?(arg = nil)
+    if block_given? && arg.nil?
+      my_each { |n| return false if yield(n) }
+    elsif arg.nil?
+      my_each { |n| return false if n }
+    elsif arg.is_a?(Regexp)
+      my_each { |n| return false if arg.match(n) }
+    elsif arg.is_a?(Integer) || arg.is_a?(String)
+      my_each { |n| return false if n == arg }
+    else
+      my_each { |n| return false if n.is_a?(arg) }
+    end
+    true
+  end
+
+  def my_count(arg = nil)
+    count = 0
+    if block_given? && arg.nil?
+      my_each { |n| count += 1 if yield(n) }
+    elsif arg.nil?
+      my_each { |n| count += 1 if n }
+    elsif arg.is_a?(Integer) || arg.is_a?(String)
+      my_each { |n| count += 1 if n == arg }
+    else
+      my_each { |n| count += 1 if n.is_a?(arg) }
+    end
+    count
+  end
 end
 
 # rubocop:enable all

--- a/main.rb
+++ b/main.rb
@@ -26,14 +26,14 @@ module Enumerable
   end
 
   def my_all?(arg = nil)
-    if block_given? && arg.nil?
-      my_each { |n| return false unless yield(n) }
-    elsif arg.nil?
-      my_each { |n| return false unless n }
-    elsif arg.is_a?(Regexp)
+    if arg.is_a?(Regexp)
       my_each { |n| return false unless arg.match(n) }
     elsif arg.is_a?(Integer) || arg.is_a?(String)
       my_each { |n| return false unless n == arg }
+    elsif block_given?
+      my_each { |n| return false unless yield(n) }
+    elsif arg.nil?
+      my_each { |n| return false unless n }
     else
       my_each { |n| return false unless n.is_a?(arg) }
     end
@@ -41,14 +41,14 @@ module Enumerable
   end
 
   def my_any?(arg = nil)
-    if block_given? && arg.nil?
-      my_each { |n| return true if yield(n) }
-    elsif arg.nil?
-      my_each { |n| return true if n }
-    elsif arg.is_a?(Regexp)
+    if arg.is_a?(Regexp)
       my_each { |n| return true if arg.match(n) }
     elsif arg.is_a?(Integer) || arg.is_a?(String)
       my_each { |n| return true if n == arg }
+    elsif block_given?
+      my_each { |n| return true if yield(n) }
+    elsif arg.nil?
+      my_each { |n| return true if n }
     else
       my_each { |n| return true if n.is_a?(arg) }
     end
@@ -56,14 +56,14 @@ module Enumerable
   end
 
   def my_none?(arg = nil)
-    if block_given? && arg.nil?
-      my_each { |n| return false if yield(n) }
-    elsif arg.nil?
-      my_each { |n| return false if n }
-    elsif arg.is_a?(Regexp)
+    if arg.is_a?(Regexp)
       my_each { |n| return false if arg.match(n) }
     elsif arg.is_a?(Integer) || arg.is_a?(String)
       my_each { |n| return false if n == arg }
+    elsif block_given?
+      my_each { |n| return false if yield(n) }
+    elsif arg.nil?
+      my_each { |n| return false if n }
     else
       my_each { |n| return false if n.is_a?(arg) }
     end

--- a/main.rb
+++ b/main.rb
@@ -10,4 +10,13 @@ module Enumerable
       yield object[n]
     end
   end
+
+  def my_each_with_index
+    return to_enum unless block_given?
+
+    object = self
+    object.size.times do |n|
+      yield object[n], n
+    end
+  end
 end


### PR DESCRIPTION
This branch includes the following:

- The rewritten methods: my_each, my_each_with_index, my_select, my_all?, my_any?, my_none?, my_count, my_map, my_inject and multiply_els.
- Rubocop and stickler linter files
- Appropriate readme file